### PR TITLE
Bugfix/menu hashes

### DIFF
--- a/src/main/java/org/rev317/min/accessors/Client.java
+++ b/src/main/java/org/rev317/min/accessors/Client.java
@@ -37,6 +37,8 @@ public interface Client {
 
     int[] getMenuActionId();
 
+    long[] getMenuHash();
+
     int[] getMenuAction1();
 
     int[] getMenuAction2();

--- a/src/main/java/org/rev317/min/accessors/SceneObjectTile.java
+++ b/src/main/java/org/rev317/min/accessors/SceneObjectTile.java
@@ -1,0 +1,6 @@
+package org.rev317.min.accessors;
+
+public interface SceneObjectTile {
+
+    long getHash();
+}

--- a/src/main/java/org/rev317/min/api/methods/Menu.java
+++ b/src/main/java/org/rev317/min/api/methods/Menu.java
@@ -1,5 +1,8 @@
 package org.rev317.min.api.methods;
 
+import org.parabot.core.Context;
+import org.parabot.core.reflect.RefClass;
+import org.parabot.core.ui.Logger;
 import org.rev317.min.Loader;
 import org.rev317.min.accessors.Client;
 import org.rev317.min.api.wrappers.Character;
@@ -301,9 +304,27 @@ public class Menu {
      * @param index
      */
     public static void sendAction(int action, int cmd1, int cmd2, int cmd3, int index) {
-        sendAction(action, cmd1, cmd2, cmd3, 0, index);
+        sendAction(action, cmd1, cmd2, cmd3, 0L, index);
     }
 
+    /**
+     *
+     * @param action
+     * @param cmd1
+     * @param cmd2
+     * @param cmd3
+     * @param hash
+     * @param index
+     */
+    public static void sendAction(int action, int cmd1, int cmd2, int cmd3, long hash, int index) {
+        Client client = Loader.getClient();
+        client.getMenuHash()[index] = hash;
+        client.getMenuAction1()[index] = cmd1;
+        client.getMenuAction2()[index] = cmd2;
+        client.getMenuAction3()[index] = cmd3;
+        client.getMenuActionId()[index] = action;
+        client.performAction(index);
+    }
     /**
      * Sends an action to the client
      *
@@ -315,16 +336,6 @@ public class Menu {
      * @param index
      */
     public static void sendAction(int action, int cmd1, int cmd2, int cmd3, int cmd4, int index) {
-        Client client = Loader.getClient();
-
-        client.getMenuAction1()[index] = cmd1;
-        client.getMenuAction2()[index] = cmd2;
-        client.getMenuAction3()[index] = cmd3;
-        if (Game.hasAction4()) {
-            client.getMenuAction4()[index] = cmd4;
-        }
-        client.getMenuActionId()[index] = action;
-
-        client.performAction(index);
+        throw new UnsupportedOperationException("RuneWild cannot use #sendAction with a parameter of [int cmd4]. Use #sendAction with [long Hash] instead.");
     }
 }

--- a/src/main/java/org/rev317/min/api/wrappers/SceneObject.java
+++ b/src/main/java/org/rev317/min/api/wrappers/SceneObject.java
@@ -1,0 +1,128 @@
+package org.rev317.min.api.wrappers;
+
+import org.parabot.core.reflect.RefClass;
+import org.rev317.min.accessors.SceneObjectTile;
+import org.rev317.min.api.interfaces.Locatable;
+import org.rev317.min.api.methods.Calculations;
+import org.rev317.min.api.methods.Game;
+import org.rev317.min.api.methods.Menu;
+import org.rev317.min.api.methods.SceneObjects;
+
+/**
+ * @author Everel
+ * Custom code is #getHashLong and its usages in getLocalRegion X,Y and ID
+ */
+public class SceneObject implements Locatable {
+    public static final int TYPE_WALL             = 0; // object1
+    public static final int TYPE_WALLDECORATION   = 1; // object2
+    public static final int TYPE_GROUNDDECORATION = 2; // object3
+    public static final int TYPE_GROUNDITEM       = 3; // object4
+    public static final int TYPE_INTERACTIVE      = 4; // object5
+
+    public  SceneObjectTile accessor;
+    private int             type;
+
+    public SceneObject(SceneObjectTile accessor, int type) {
+        this.accessor = accessor;
+        this.type = type;
+    }
+
+    /**
+     * Gets this object's hash
+     *
+     * @return hash
+     */
+    public final int getHash() {
+        return (int) getHashLong();
+    }
+
+    public final long getHashLong() { return accessor.getHash(); }
+
+    /**
+     * Gets location of this tile
+     *
+     * @return location
+     */
+    public final Tile getLocation() {
+        return new Tile(Game.getBaseX() + getLocalRegionX(), Game.getBaseY() + getLocalRegionY());
+    }
+
+    /**
+     * Gets region X
+     *
+     * @return region X
+     */
+    public final int getLocalRegionX() {
+        return (int) (getHashLong() & 0x7f);
+    }
+
+    /**
+     * Gets region Y
+     *
+     * @return region Y
+     */
+    public final int getLocalRegionY() {
+        return (int) (getHashLong() >> 7 & 0x7f);
+    }
+
+    /**
+     * Gets this object's id
+     *
+     * @return object id
+     */
+    public final int getId() {
+        return (int) ((getHashLong() >>> 32) & 0x7FFF);
+    }
+
+    /**
+     * Gets this object's type
+     *
+     * @return type of object
+     */
+    public final int getType() {
+        return type;
+    }
+
+    /**
+     * Calculates distance to this object
+     *
+     * @return distance
+     */
+    public final int distanceTo() {
+        return (int) Calculations.distanceTo(getLocation());
+    }
+
+    /**
+     * Interacts with this object
+     *
+     * @param option
+     */
+    public void interact(SceneObjects.Option option) {
+        Menu.interact(this, option);
+    }
+
+    /**
+     * Interacts with this object
+     *
+     * @param actionIndex
+     *
+     * @deprecated
+     */
+    public void interact(int actionIndex) {
+        Menu.interact(this, actionIndex);
+    }
+
+    /**
+     * Gets the accessor class
+     *
+     * @return RefClass of accessor
+     */
+    public RefClass getRefClass() {
+        return new RefClass(this.accessor);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[ID: %d, X: %d, Y: %d]", getId(), getLocalRegionX(), getLocalRegionY());
+    }
+}

--- a/src/main/java/org/rev317/min/callback/MenuAction.java
+++ b/src/main/java/org/rev317/min/callback/MenuAction.java
@@ -1,0 +1,66 @@
+package org.rev317.min.callback;
+
+import org.rev317.min.Loader;
+import org.rev317.min.accessors.Client;
+import org.rev317.min.api.events.GameActionEvent;
+import org.rev317.min.api.methods.Game;
+import org.rev317.min.debug.DActions;
+import org.rev317.min.script.ScriptEngine;
+
+/**
+ * @author Everel, JKetelaar, Matt123337
+ * Custom code is client.getMenuHash()[index]
+ */
+public class MenuAction {
+
+    private static final String[][] outputs            = {
+            {
+                    "[index: %d, action1: %d, action2: %d, action3: %d, action4: %d, id: %d]",
+                    "[id: %d, action1: %d, action2: %d, action3: %d, action4: %d, index: %d]"
+            },
+            {
+                    "[index: %d, action1: %d, action2: %d, action3: %d, id: %d, hash: %d]",
+                    "[id: %d, action1: %d, action2: %d, action3: %d, index: %d, hash: %d]"
+            }
+    };
+    private static       int        currentOutputIndex = 0;
+
+    public static void intercept(int index) {
+        int outputIndex = 0;
+
+        Client client   = Loader.getClient();
+        long   hashId  = client.getMenuHash()[index]; // Unique to RuneWild
+        int    action1  = client.getMenuAction1()[index];
+        int    action2  = client.getMenuAction2()[index];
+        int    action3  = client.getMenuAction3()[index];
+        int    action4  = 0;
+        int    actionId = client.getMenuActionId()[index];
+        if (DActions.debugActions()) {
+            if (Game.hasAction4()) {
+                action4 = client.getMenuAction4()[index];
+                System.out.println(String.format(outputs[0][outputIndex], index, action1, action2, action3, action4, actionId));
+            } else {
+                System.out.println(String.format(outputs[1][outputIndex], index, action1, action2, action3, actionId, hashId));
+            }
+        }
+
+        final GameActionEvent actionEvent = new GameActionEvent(actionId, action1, action2, action3, action4, index);
+        ScriptEngine.getInstance().dispatch(actionEvent);
+    }
+
+    /**
+     * Sets the current output index
+     *
+     * @param currentOutputIndex
+     */
+    public static void setCurrentOutputIndex(int currentOutputIndex) {
+        if (currentOutputIndex > outputs.length) {
+            currentOutputIndex = 0;
+        }
+        MenuAction.currentOutputIndex = currentOutputIndex;
+    }
+
+    public static String[][] getOutputs() {
+        return outputs;
+    }
+}


### PR DESCRIPTION
Fix getX, Y and ID by using a Long Hash which has a unique format in RuneWild. An example is 
` id =(int) ((getHashLong() >>> 32) & 0x7FFF);`

where the id in 317s is usually `>> 14` instead of 32.